### PR TITLE
Use a linear store for references

### DIFF
--- a/debezium-scripting/debezium-scripting/src/main/java/io/debezium/transforms/scripting/WasmEngine.java
+++ b/debezium-scripting/debezium-scripting/src/main/java/io/debezium/transforms/scripting/WasmEngine.java
@@ -94,7 +94,6 @@ public class WasmEngine implements Engine {
     @Override
     public <T> T eval(ConnectRecord<?> record, Class<T> type) {
         Map<String, Object> bindings = getBindings(record);
-        engine.registerProxyObject(bindings);
 
         try {
             final Object result = engine.eval(bindings);
@@ -107,9 +106,6 @@ public class WasmEngine implements Engine {
         }
         catch (Exception e) {
             throw new DebeziumException("Error while evaluating wasm file '" + expression + "' for record '" + record + "'", e);
-        }
-        finally {
-            engine.clearReferences();
         }
     }
 }


### PR DESCRIPTION
This is simpler, more self-contained and resistant to issues caused by objects clashing hash-codes.
When we look at performance, it might be good to switch to a plain array, let me know if you want this change to be included now.

cc. @jpechane